### PR TITLE
fixup! Add support for dynamic BuildRequires

### DIFF
--- a/build/build.c
+++ b/build/build.c
@@ -273,9 +273,7 @@ static rpmRC doBuildRequires(rpmSpec spec, int test) {
 
     rpmdsPutToHeader(*packageDependencies(spec->sourcePackage, RPMTAG_REQUIRENAME), spec->sourcePackage->header);
 
-    if (rc == 0) {
-	parseRCPOT(spec, spec->sourcePackage, "DynamicBuildRequires = 4.15.0", RPMTAG_PROVIDENAME, 0, 0, addReqProvPkg , NULL);
-    }
+    parseRCPOT(spec, spec->sourcePackage, "rpmlib(DynamicBuildRequires) = 4.15.0-1", RPMTAG_PROVIDENAME, 0, 0, addReqProvPkg , NULL);
 
  exit:
     free(argv);

--- a/build/build.c
+++ b/build/build.c
@@ -274,7 +274,7 @@ static rpmRC doBuildRequires(rpmSpec spec, int test) {
     rpmdsPutToHeader(*packageDependencies(spec->sourcePackage, RPMTAG_REQUIRENAME), spec->sourcePackage->header);
 
     if (rc == 0) {
-	parseRCPOT(spec, spec->sourcePackage, "DynamicBuildRequires = 4.15", RPMTAG_PROVIDENAME, 0, 0, addReqProvPkg , NULL);
+	parseRCPOT(spec, spec->sourcePackage, "DynamicBuildRequires = 4.15.0", RPMTAG_PROVIDENAME, 0, 0, addReqProvPkg , NULL);
     }
 
  exit:

--- a/build/pack.c
+++ b/build/pack.c
@@ -742,7 +742,7 @@ rpmRC packageSources(rpmSpec spec, char **cookie)
     headerPutUint32(sourcePkg->header, RPMTAG_SOURCEPACKAGE, &one, 1);
 
     if (spec->buildrequires) {
-	(void) rpmlibNeedsFeature(sourcePkg, "DynamicBuildRequires", "4.15-1");
+	(void) rpmlibNeedsFeature(sourcePkg, "DynamicBuildRequires", "4.15.0-1");
     }
 
     /* XXX this should be %_srpmdir */

--- a/lib/rpmds.c
+++ b/lib/rpmds.c
@@ -1249,6 +1249,9 @@ static const struct rpmlibProvides_s rpmlibProvides[] = {
     { "rpmlib(RichDependencies)",    "4.12.0-1",
 	(		RPMSENSE_EQUAL),
     N_("support for rich dependencies.") },
+    { "rpmlib(DynamicBuildRequires)", "4.15.0-1",
+	(RPMSENSE_RPMLIB|RPMSENSE_EQUAL),
+    N_("support for dynamic buildrequires.") },
 #ifdef HAVE_ZSTD
     { "rpmlib(PayloadIsZstd)",		"5.4.18-1",
 	(RPMSENSE_RPMLIB|RPMSENSE_EQUAL),


### PR DESCRIPTION
* Add missing rpmds provide for rpmlib() feature
* Use 4.15.0 (instead of 4.15) for consistency